### PR TITLE
Refactor Parser class to eliminate arrowhead anti-pattern

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -1,3 +1,5 @@
 T | 1 | Buy groceries
 T | 0 | read a book
 T | 1 | running
+T | 1 | Buy groceries
+E | 0 | Team meeting | 2019-12-02 1400 | 2019-12-02 1600

--- a/src/main/java/Buu/Parser.java
+++ b/src/main/java/Buu/Parser.java
@@ -1,4 +1,5 @@
 package Buu;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,7 +18,6 @@ public class Parser {
      * @return The corresponding Command object based on the input.
      * @throws GPTException If the input cannot be parsed into a valid command.
      */
-
     public static Command parseCommand(String input) throws GPTException {
         if (input.equalsIgnoreCase("bye")) {
             return new ExitCommand();
@@ -35,7 +35,7 @@ public class Parser {
             return new DeadlineCommand(input);
         } else if (input.startsWith("event")) {
             return new EventCommand(input);
-        } else if (input.startsWith("find")) { // Added "find" command
+        } else if (input.startsWith("find")) {
             return new FindCommand(input);
         } else {
             return new HelpCommand(); // Return a HelpCommand when an unrecognized input is entered
@@ -51,36 +51,62 @@ public class Parser {
      * @return A LocalDateTime object representing the parsed date and time, or null if the input is invalid.
      */
     public static LocalDateTime parseDateTime(String dateTimeStr) {
-        DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
-        DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
-        DateTimeFormatter formatter3 = DateTimeFormatter.ofPattern("yyyy-M-d HHmm");
-        DateTimeFormatter formatter4 = DateTimeFormatter.ofPattern("d/M/yyyy");
-        DateTimeFormatter formatter5 = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDateTime dateTime = parseWithDateTimeFormatter(dateTimeStr, "yyyy-MM-dd HHmm");
+        if (dateTime != null) {
+            return dateTime;
+        }
 
+        dateTime = parseWithDateTimeFormatter(dateTimeStr, "d/M/yyyy HHmm");
+        if (dateTime != null) {
+            return dateTime;
+        }
+
+        dateTime = parseWithDateTimeFormatter(dateTimeStr, "yyyy-M-d HHmm");
+        if (dateTime != null) {
+            return dateTime;
+        }
+
+        LocalDate date = parseWithDateFormatter(dateTimeStr, "d/M/yyyy");
+        if (date != null) {
+            return date.atStartOfDay();
+        }
+
+        date = parseWithDateFormatter(dateTimeStr, "yyyy-MM-dd");
+        if (date != null) {
+            return date.atStartOfDay();
+        }
+
+        System.out.println("Invalid date format. Please use yyyy-MM-dd HHmm, d/M/yyyy HHmm, or yyyy-MM-dd format.");
+        return null;
+    }
+
+    /**
+     * Attempts to parse a date-time string with the given format.
+     * @param dateTimeStr The date-time string to parse.
+     * @param pattern The date-time pattern to use.
+     * @return A LocalDateTime object if parsing is successful, or null if an exception occurs.
+     */
+    private static LocalDateTime parseWithDateTimeFormatter(String dateTimeStr, String pattern) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
         try {
-            return LocalDateTime.parse(dateTimeStr, formatter1);
+            return LocalDateTime.parse(dateTimeStr, formatter);
         } catch (DateTimeParseException e) {
-            try {
-                return LocalDateTime.parse(dateTimeStr, formatter2);
-            } catch (DateTimeParseException ex) {
-                try {
-                    return LocalDateTime.parse(dateTimeStr, formatter3);
-                } catch (DateTimeParseException exc) {
-                    try {
-                        LocalDate date = LocalDate.parse(dateTimeStr, formatter4);
-                        return date.atStartOfDay();
-                    } catch (DateTimeParseException exc2) {
-                        try {
-                            LocalDate date = LocalDate.parse(dateTimeStr, formatter5);
-                            return date.atStartOfDay();
-                        } catch (DateTimeParseException exc3) {
-                            System.out.println("Invalid date format. Please use yyyy-MM-dd HHmm, "
-                                    + "d/M/yyyy HHmm, or yyyy-MM-dd format.");
-                            return null;
-                        }
-                    }
-                }
-            }
+            return null; // Return null to indicate a parsing failure
+        }
+    }
+
+    /**
+     * Attempts to parse a date string with the given format.
+     * @param dateStr The date string to parse.
+     * @param pattern The date pattern to use.
+     * @return A LocalDate object if parsing is successful, or null if an exception occurs.
+     */
+    private static LocalDate parseWithDateFormatter(String dateStr, String pattern) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        try {
+            return LocalDate.parse(dateStr, formatter);
+        } catch (DateTimeParseException e) {
+            return null; // Return null to indicate a parsing failure
         }
     }
 }


### PR DESCRIPTION
Refactor Parser class to eliminate arrowhead anti-pattern

Refactored the `parseDateTime` method in the `Parser` class to remove 
nested try-catch blocks and avoid the arrowhead anti-pattern. 
This improves code readability and maintainability by reducing 
deep nesting and simplifying the control flow.

The refactoring maintains the functionality of parsing date strings 
using multiple predefined formats, ensuring invalid inputs are 
handled appropriately and providing feedback for invalid formats.
