### PR TITLE
Refactor Parser class to use Streams for date parsing

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -1,1 +1,2 @@
-T | 1 | running
+D | 0 | Submit assignment | 2019-12-02 1700
+E | 0 | Team meeting | 2019-12-02 1400 | 2019-12-02 1600


### PR DESCRIPTION
Refactored the `parseDateTime` method in the `Parser` class to utilize 
Java Streams for cleaner and more efficient code. Streams are now 
used to attempt parsing with various date and time formats, and 
Optional is returned to handle success or failure gracefully.

This approach reduces nested if-else statements (arrowhead code) 
and enhances readability and maintainability of the code. DateTime 
and Date parsing functions have been separated for better structure.
